### PR TITLE
Specify proxy in Transport.

### DIFF
--- a/dynectsoap/soapclient.go
+++ b/dynectsoap/soapclient.go
@@ -279,6 +279,7 @@ func (s *Client) Call(soapAction string, request, response interface{}) error {
 
 	tr := &http.Transport{
 		TLSClientConfig: s.opts.tlsCfg,
+		Proxy: http.ProxyFromEnvironment,
 		Dial: func(network, addr string) (net.Conn, error) {
 			return net.DialTimeout(network, addr, s.opts.timeout)
 		},


### PR DESCRIPTION
This PR specifies the HTTP proxy (if any) in the setup of the transport so that the library works in environments where an HTTP proxy is required. 

See also:
1. http://golang.org/pkg/net/http/#ProxyFromEnvironment
2. http://golang.org/pkg/net/http/#Transport
3. https://github.com/sanyu/dynectsoap/issues/1
